### PR TITLE
Updated phpmyadmin.conf

### DIFF
--- a/.docker/nginx/conf.d/phpmyadmin.conf
+++ b/.docker/nginx/conf.d/phpmyadmin.conf
@@ -1,7 +1,7 @@
 server {
     listen      80;
     listen      [::]:80;
-    server_name phpmyadmin.test;
+    server_name phpmyadmin.demo.test;
     root        /var/www/phpmyadmin;
     index       index.php;
 


### PR DESCRIPTION
changed `server_name  phpmyadmin.test` to `server_name phpmyadmin.demo.test` 
We generated the openssl-certificate for demo.test and *.demo.test
and by doing so we also have to edit that change in our etc/hosts file on our machine