### PR TITLE
Fix mysql configuration path

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
       MYSQL_ROOT_HOST: "%"
       MYSQL_DATABASE: demo
     volumes:
-      - ./.docker/mysql/my.cnf:/etc/mysql/conf.d/my.cnf
+      - ./.docker/mysql/my.cnf:/etc/mysql/my.cnf
       - mysqldata:/var/lib/mysql
     healthcheck:
       test: mysqladmin ping -h 127.0.0.1 -u root --password=$$MYSQL_ROOT_PASSWORD


### PR DESCRIPTION
If I use the following command
`/usr/sbin/mysqld --verbose --help | grep -A 1 "Default options"`

inside mysql service container, I see only the following paths loaded (image mysql/mysql-server:8.0)
- /etc/my.cnf 
- /etc/mysql/my.cnf 
- /usr/etc/my.cnf 
- ~/.my.cnf 

So I could load my own my.cnf only with the proposed path update.